### PR TITLE
feature/#12: 수량 선택 버튼 구현

### DIFF
--- a/app/src/main/java/org/techtown/twosomeheart/core/component/QuantityButton.kt
+++ b/app/src/main/java/org/techtown/twosomeheart/core/component/QuantityButton.kt
@@ -1,0 +1,103 @@
+package org.techtown.twosomeheart.core.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.techtown.twosomeheart.R
+import org.techtown.twosomeheart.core.extension.noRippleClickable
+import org.techtown.twosomeheart.ui.theme.Black
+import org.techtown.twosomeheart.ui.theme.Gray20
+import org.techtown.twosomeheart.ui.theme.TwosomeHeartTheme
+import org.techtown.twosomeheart.ui.theme.White
+
+@Composable
+fun ModalQuantityButton(
+    onClickMinusButton: () -> Unit,
+    onClickPlusButton: () -> Unit,
+    modifier: Modifier = Modifier,
+    ammount: Int = 1,
+) {
+    Row(
+        modifier = modifier
+            .height(32.dp)
+            .border(width = 1.dp, shape = RoundedCornerShape(4.dp), color = Gray20)
+            .clip(RoundedCornerShape(4.dp))
+            .background(White),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier.noRippleClickable(onClick = onClickMinusButton)
+        ) {
+            Icon(
+                imageVector = ImageVector.vectorResource(id = R.drawable.ic_modal_minus),
+                contentDescription = stringResource(R.string.minus),
+                tint = Color.Unspecified,
+                modifier = Modifier
+                    .size(24.dp)
+                    .padding(4.dp),
+            )
+        }
+
+        Box(
+            modifier = Modifier
+                .width(40.dp)
+                .height(32.dp)
+                .border(width = 1.dp, color = Gray20),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = ammount.toString(),
+                color = Black,
+                style = TwosomeHeartTheme.typography.body1B14Tight
+            )
+        }
+
+        Box(
+            modifier = Modifier.noRippleClickable(onClick = onClickPlusButton)
+        ) {
+            Icon(
+                imageVector = ImageVector.vectorResource(id = R.drawable.ic_modal_plus),
+                contentDescription = stringResource(R.string.plus),
+                tint = Color.Unspecified,
+                modifier = Modifier
+                    .size(24.dp)
+                    .padding(4.dp),
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun QuantityButtonPreview() {
+    TwosomeHeartTheme {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(20.dp)
+        ) {
+            ModalQuantityButton(
+                onClickMinusButton = {},
+                onClickPlusButton = {}
+            )
+        }
+    }
+}

--- a/app/src/main/java/org/techtown/twosomeheart/core/component/QuantityButton.kt
+++ b/app/src/main/java/org/techtown/twosomeheart/core/component/QuantityButton.kt
@@ -28,6 +28,7 @@ import org.techtown.twosomeheart.core.extension.noRippleClickable
 import org.techtown.twosomeheart.ui.theme.Black
 import org.techtown.twosomeheart.ui.theme.Gray20
 import org.techtown.twosomeheart.ui.theme.TwosomeHeartTheme
+import org.techtown.twosomeheart.ui.theme.TwosomeHeartTypography
 import org.techtown.twosomeheart.ui.theme.White
 
 @Composable
@@ -68,7 +69,7 @@ fun ModalQuantityButton(
             Text(
                 text = ammount.toString(),
                 color = Black,
-                style = TwosomeHeartTheme.typography.body1B14Tight
+                style = TwosomeHeartTypography.body1B14Tight
             )
         }
 

--- a/app/src/main/java/org/techtown/twosomeheart/core/component/QuantityButton.kt
+++ b/app/src/main/java/org/techtown/twosomeheart/core/component/QuantityButton.kt
@@ -87,6 +87,69 @@ fun ModalQuantityButton(
     }
 }
 
+@Composable
+fun OptionQuantityButton(
+    onClickMinusButton: () -> Unit,
+    onClickPlusButton: () -> Unit,
+    modifier: Modifier = Modifier,
+    ammount: Int = 0,
+) {
+    Row(
+        modifier = modifier
+            .height(32.dp)
+            .border(width = 1.dp, shape = RoundedCornerShape(4.dp), color = Gray20)
+            .clip(RoundedCornerShape(4.dp))
+            .background(White),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier.noRippleClickable(
+                onClick = {
+                    if (ammount == 0) else onClickMinusButton()
+                }
+            )
+        ) {
+            Icon(
+                imageVector = if (ammount == 0) ImageVector.vectorResource(id = R.drawable.ic_option_more_minus_disable) else ImageVector.vectorResource(
+                    id = R.drawable.ic_option_more_minus_able
+                ),
+                contentDescription = stringResource(R.string.minus),
+                tint = Color.Unspecified,
+                modifier = Modifier
+                    .size(24.dp)
+                    .padding(4.dp),
+            )
+        }
+
+        Box(
+            modifier = Modifier
+                .width(40.dp)
+                .height(32.dp)
+                .border(width = 1.dp, color = Gray20),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = ammount.toString(),
+                color = Black,
+                style = TwosomeHeartTheme.typography.caption1M12
+            )
+        }
+
+        Box(
+            modifier = Modifier.noRippleClickable(onClick = onClickPlusButton)
+        ) {
+            Icon(
+                imageVector = ImageVector.vectorResource(id = R.drawable.ic_option_more_plus),
+                contentDescription = stringResource(R.string.plus),
+                tint = Color.Unspecified,
+                modifier = Modifier
+                    .size(24.dp)
+                    .padding(4.dp),
+            )
+        }
+    }
+}
+
 @Preview
 @Composable
 fun QuantityButtonPreview() {
@@ -97,6 +160,15 @@ fun QuantityButtonPreview() {
             ModalQuantityButton(
                 onClickMinusButton = {},
                 onClickPlusButton = {}
+            )
+            OptionQuantityButton(
+                onClickMinusButton = {},
+                onClickPlusButton = {}
+            )
+            OptionQuantityButton(
+                onClickMinusButton = {},
+                onClickPlusButton = {},
+                ammount = 1
             )
         }
     }

--- a/app/src/main/res/drawable/ic_modal_minus.xml
+++ b/app/src/main/res/drawable/ic_modal_minus.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:strokeWidth="1"
+      android:pathData="M6,12L18,12"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"/>
+</vector>

--- a/app/src/main/res/drawable/ic_modal_plus.xml
+++ b/app/src/main/res/drawable/ic_modal_plus.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:strokeWidth="1"
+      android:pathData="M6,12L18,12"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"/>
+  <path
+      android:strokeWidth="1"
+      android:pathData="M12,18L12,6"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"/>
+</vector>

--- a/app/src/main/res/drawable/ic_option_more_minus_able.xml
+++ b/app/src/main/res/drawable/ic_option_more_minus_able.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:strokeWidth="1"
+      android:pathData="M8,12L16,12"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"/>
+</vector>

--- a/app/src/main/res/drawable/ic_option_more_minus_disable.xml
+++ b/app/src/main/res/drawable/ic_option_more_minus_disable.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:strokeWidth="1"
+      android:pathData="M8,12L16,12"
+      android:fillColor="#00000000"
+      android:strokeColor="#999999"/>
+</vector>

--- a/app/src/main/res/drawable/ic_option_more_plus.xml
+++ b/app/src/main/res/drawable/ic_option_more_plus.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:strokeWidth="1"
+      android:pathData="M8,12L16,12"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"/>
+  <path
+      android:strokeWidth="1"
+      android:pathData="M12,16L12,8"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,8 @@
 <resources>
     <string name="app_name">Twosome Heart</string>
     <string name="dummy_example_string">dummy_string</string>
+
+    //common
+    <string name="minus">minus</string>
+    <string name="plus">plus</string>
 </resources>


### PR DESCRIPTION
# PR Convention

## ☕ ISSUE
- closed #12 

## ❗ WORK DESCRIPTION
- 모달창에서 사용되는/옵션창에서 사용되는 수량 버튼을 구현했습니다
- 모달창과 옵션창이 같은 조건이라고 생각했는데 실제로 아이콘이나 글자폰트 등 다른 부분이 있어서 두 개의 컴포넌트로 분리했습니다! 수량에 대한 기본값도 다르게 설정했습니다!

## 📸 SCREENSHOT
<img src="https://github.com/user-attachments/assets/40036941-5420-4d11-b5ee-00f142f9270a" width="300" />

## 📢 TO REVIEWERS
- 피드백 부탁드려요오
- 두 컴포넌트가 겹치는 부분이 많은데 어떤식으로 활용할 수 있을까요? 흐으음
