### PR TITLE
feature/#42: 마이투썸 삭제 API 연동

### DIFF
--- a/app/src/main/java/org/techtown/twosomeheart/data/dto/response/ResponseMyMenuDeleteDTO.kt
+++ b/app/src/main/java/org/techtown/twosomeheart/data/dto/response/ResponseMyMenuDeleteDTO.kt
@@ -1,0 +1,10 @@
+package org.techtown.twosomeheart.data.dto.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ResponseMyMenuDeleteDTO(
+    @SerialName("status")
+    val status: Int
+)

--- a/app/src/main/java/org/techtown/twosomeheart/data/service/TwosomeService.kt
+++ b/app/src/main/java/org/techtown/twosomeheart/data/service/TwosomeService.kt
@@ -1,9 +1,12 @@
 package org.techtown.twosomeheart.data.service
 
 import org.techtown.twosomeheart.data.dto.response.ResponseMenuDetailDto
+import org.techtown.twosomeheart.data.dto.response.ResponseMyMenuDeleteDTO
 import org.techtown.twosomeheart.data.dto.response.ResponseMyMenuDto
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.Path
+import retrofit2.http.Query
 
 interface TwosomeService {
     //menu detail
@@ -15,4 +18,9 @@ interface TwosomeService {
   
     @GET("api/v1/likes")
     suspend fun getMyMenu(): ResponseMyMenuDto
-}
+
+    @DELETE("api/v1/likes")
+    suspend fun deleteMyMenu(
+        @Query("favoriteIds") favoriteIds: String? = null,
+        @Query("all") all: Boolean = false
+    ): ResponseMyMenuDeleteDTO}

--- a/app/src/main/java/org/techtown/twosomeheart/data/service/TwosomeService.kt
+++ b/app/src/main/java/org/techtown/twosomeheart/data/service/TwosomeService.kt
@@ -1,6 +1,7 @@
 package org.techtown.twosomeheart.data.service
 
 import org.techtown.twosomeheart.data.dto.response.ResponseMenuDetailDto
+import org.techtown.twosomeheart.data.dto.response.ResponseMyMenuDto
 import retrofit2.http.GET
 import retrofit2.http.Path
 

--- a/app/src/main/java/org/techtown/twosomeheart/presentation/mymenu/MyMenuRoute.kt
+++ b/app/src/main/java/org/techtown/twosomeheart/presentation/mymenu/MyMenuRoute.kt
@@ -123,8 +123,14 @@ fun MyMenuScreen(
             )
 
             Text(
-                text = "총 3개",
-                // TODO 서버통신 값 할당
+                text = when (state) {
+                    is UiState.Loading -> ""
+                    is UiState.Empty -> "항목이 없습니다."
+                    is UiState.Failure -> "불러오기에 실패했습니다."
+                    is UiState.Success -> {
+                        "총 ${state.data.size}개"
+                    }
+                },
                 style = TwosomeHeartTypography.caption1R12Tight,
                 color = TwosomeHeartColors.Gray90,
                 modifier = Modifier.padding(start = 16.dp, top = 23.dp)

--- a/app/src/main/java/org/techtown/twosomeheart/presentation/mymenu/MyMenuRoute.kt
+++ b/app/src/main/java/org/techtown/twosomeheart/presentation/mymenu/MyMenuRoute.kt
@@ -120,7 +120,7 @@ fun MyMenuScreen(
                         modifier = Modifier.noRippleClickable(onClick = navigateUp)
                     )
                 },
-                text = stringResource(R.string.menu_top_bar),
+                text = stringResource(R.string.my_menu_navigate_text),
                 trailingIcon = {
                     Icon(
                         imageVector = ImageVector.vectorResource(R.drawable.ic_mymenu_plus),

--- a/app/src/main/java/org/techtown/twosomeheart/presentation/mymenu/MyMenuRoute.kt
+++ b/app/src/main/java/org/techtown/twosomeheart/presentation/mymenu/MyMenuRoute.kt
@@ -46,6 +46,7 @@ import org.techtown.twosomeheart.presentation.mymenu.component.CustomDialog
 import org.techtown.twosomeheart.presentation.mymenu.component.MyMenuBottomSheet
 import org.techtown.twosomeheart.presentation.mymenu.component.MyMenuItem
 import org.techtown.twosomeheart.presentation.mymenu.model.MyMenuModel
+import org.techtown.twosomeheart.presentation.mymenu.model.SelectedSummary
 import org.techtown.twosomeheart.ui.theme.TwosomeHeartColors
 import org.techtown.twosomeheart.ui.theme.TwosomeHeartTheme
 import org.techtown.twosomeheart.ui.theme.TwosomeHeartTypography
@@ -58,6 +59,7 @@ fun MyMenuRoute(
     viewModel: MyMenuViewModel = viewModel()
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
+    val selectedSummary by viewModel.selectedSummary.collectAsStateWithLifecycle()
 
     LaunchedEffect(true) {
         viewModel.getMyMenu()
@@ -68,7 +70,8 @@ fun MyMenuRoute(
         state = state.uiState,
         navigateUp = navigateUp,
         toggleItemChecked = viewModel::toggleItemChecked,
-        deleteSelectedItems = viewModel::deleteSelectedItems
+        deleteSelectedItems = viewModel::deleteSelectedItems,
+        selectedSummary = selectedSummary
     )
 }
 
@@ -79,8 +82,10 @@ fun MyMenuScreen(
     state: UiState<PersistentList<MyMenuModel>>,
     navigateUp: () -> Unit,
     toggleItemChecked: (Int, Boolean, Boolean) -> Unit,
-    deleteSelectedItems: (isAll: Boolean) -> Unit
+    deleteSelectedItems: (isAll: Boolean) -> Unit,
+    selectedSummary: SelectedSummary
 ) {
+
 
     val isMyBottomSheetVisible by remember(state) {
         derivedStateOf {
@@ -232,8 +237,8 @@ fun MyMenuScreen(
             MyMenuBottomSheet(
                 modifier = Modifier
                     .align(Alignment.BottomCenter),
-                price = 5500,
-                count = stringResource(R.string.my_menu_select_count),
+                price = selectedSummary.totalPrice, // 선택된 총 금액 전달
+                count = selectedSummary.itemCount.toString(), // 선택된 총 개수 전달
                 place = stringResource(R.string.menu_ordered_store_name),
             )
         }
@@ -261,6 +266,10 @@ fun MyMenuScreenPreview() {
             navigateUp = {},
             toggleItemChecked = { _, _, _ -> },
             deleteSelectedItems = {},
+            selectedSummary = SelectedSummary(
+                itemCount = 0,
+                totalPrice = 0
+            ),
             state = UiState.Success(
                 persistentListOf(
                     MyMenuModel(
@@ -269,7 +278,7 @@ fun MyMenuScreenPreview() {
                         menuImage = "https://github.com/user-attachments/assets/4b7b216c-0ea9-4034-a88c-953a6f761f98",
                         menuOption = "아이스/라지/블랙그라운드/포장",
                         isChecked = true,
-                        id = 1
+                        id = 1,
                     ),
                     MyMenuModel(
                         menuName = "바나나 샷 아메리카노",

--- a/app/src/main/java/org/techtown/twosomeheart/presentation/mymenu/MyMenuRoute.kt
+++ b/app/src/main/java/org/techtown/twosomeheart/presentation/mymenu/MyMenuRoute.kt
@@ -67,7 +67,8 @@ fun MyMenuRoute(
         paddingValues = paddingValues,
         state = state.uiState,
         navigateUp = navigateUp,
-        toggleItemChecked = viewModel::toggleItemChecked
+        toggleItemChecked = viewModel::toggleItemChecked,
+        deleteSelectedItems = viewModel::deleteSelectedItems
     )
 }
 
@@ -77,7 +78,8 @@ fun MyMenuScreen(
     paddingValues: PaddingValues,
     state: UiState<PersistentList<MyMenuModel>>,
     navigateUp: () -> Unit,
-    toggleItemChecked: (Int, Boolean, Boolean) -> Unit
+    toggleItemChecked: (Int, Boolean, Boolean) -> Unit,
+    deleteSelectedItems: (isAll: Boolean) -> Unit
 ) {
 
     val isMyBottomSheetVisible by remember(state) {
@@ -239,8 +241,9 @@ fun MyMenuScreen(
         if (isDialogVisible) {
             CustomDialog(
                 title = stringResource(R.string.my_menu_dialog_title),
-                onClickCancel = { isDialogVisible = false }, // 다이얼로그 닫기
+                onClickCancel = { isDialogVisible = false },
                 onClickConfirm = {
+                    deleteSelectedItems(isAllSelect) // 선택 여부에 따라 전체/부분 삭제
                     isDialogVisible = false
                 }
             )
@@ -257,6 +260,7 @@ fun MyMenuScreenPreview() {
             paddingValues = PaddingValues(),
             navigateUp = {},
             toggleItemChecked = { _, _, _ -> },
+            deleteSelectedItems = {},
             state = UiState.Success(
                 persistentListOf(
                     MyMenuModel(
@@ -265,6 +269,7 @@ fun MyMenuScreenPreview() {
                         menuImage = "https://github.com/user-attachments/assets/4b7b216c-0ea9-4034-a88c-953a6f761f98",
                         menuOption = "아이스/라지/블랙그라운드/포장",
                         isChecked = true,
+                        id = 1
                     ),
                     MyMenuModel(
                         menuName = "바나나 샷 아메리카노",
@@ -272,21 +277,8 @@ fun MyMenuScreenPreview() {
                         menuImage = "https://github.com/user-attachments/assets/4b7b216c-0ea9-4034-a88c-953a6f761f98",
                         menuOption = "아이스/라지/블랙그라운드/포장/개인컵",
                         isChecked = false,
-                    ),
-                    MyMenuModel(
-                        menuName = "바나나 샷 아메리카노",
-                        menuPrice = 5800,
-                        menuImage = "https://github.com/user-attachments/assets/4b7b216c-0ea9-4034-a88c-953a6f761f98",
-                        menuOption = "아이스/라지/블랙그라운드/포장/개인컵",
-                        isChecked = false,
-                    ),
-                    MyMenuModel(
-                        menuName = "바나나 샷 아메리카노",
-                        menuPrice = 5800,
-                        menuImage = "https://github.com/user-attachments/assets/4b7b216c-0ea9-4034-a88c-953a6f761f98",
-                        menuOption = "아이스/라지/블랙그라운드/포장/개인컵",
-                        isChecked = false,
-                    ),
+                        id = 2
+                    )
                 )
             )
         )

--- a/app/src/main/java/org/techtown/twosomeheart/presentation/mymenu/MyMenuState.kt
+++ b/app/src/main/java/org/techtown/twosomeheart/presentation/mymenu/MyMenuState.kt
@@ -5,5 +5,5 @@ import org.techtown.twosomeheart.core.util.UiState
 import org.techtown.twosomeheart.presentation.mymenu.model.MyMenuModel
 
 data class MyMenuState(
-    val uiState: UiState<PersistentList<MyMenuModel>> = UiState.Loading
+    val uiState: UiState<PersistentList<MyMenuModel>> = UiState.Loading,
 )

--- a/app/src/main/java/org/techtown/twosomeheart/presentation/mymenu/MyMenuViewModel.kt
+++ b/app/src/main/java/org/techtown/twosomeheart/presentation/mymenu/MyMenuViewModel.kt
@@ -39,7 +39,7 @@ class MyMenuViewModel : ViewModel() {
                 }.toPersistentList()
 
                 _state.value = _state.value.copy(
-                    uiState = UiState.Success(favoriteList)
+                    uiState = UiState.Success(favoriteList),
                 )
             }.onFailure { throwable ->
                 _state.value = _state.value.copy(

--- a/app/src/main/java/org/techtown/twosomeheart/presentation/mymenu/MyMenuViewModel.kt
+++ b/app/src/main/java/org/techtown/twosomeheart/presentation/mymenu/MyMenuViewModel.kt
@@ -14,8 +14,12 @@ import kotlinx.coroutines.launch
 import org.techtown.twosomeheart.core.util.UiState
 import org.techtown.twosomeheart.data.ApiFactory
 import org.techtown.twosomeheart.presentation.mymenu.model.MyMenuModel
+import org.techtown.twosomeheart.presentation.mymenu.model.SelectedSummary
 
 class MyMenuViewModel : ViewModel() {
+
+    private val _selectedSummary = MutableStateFlow(SelectedSummary(0, 0))
+    val selectedSummary: StateFlow<SelectedSummary> = _selectedSummary.asStateFlow()
 
     private val twosomeService by lazy { ApiFactory.ServicePool.twosomeService }
 
@@ -104,6 +108,20 @@ class MyMenuViewModel : ViewModel() {
             _state.value = currentState.copy(
                 uiState = UiState.Success(updatedList.toPersistentList())
             )
+
+            // 총 금액 및 개수 계산
+            calculateSummary()
+        }
+    }
+
+    private fun calculateSummary() {
+        val currentState = _state.value
+        if (currentState.uiState is UiState.Success) {
+            val selectedItems = currentState.uiState.data.filter { it.isChecked }
+            val totalPrice = selectedItems.sumOf { it.menuPrice }
+            val itemCount = selectedItems.size
+
+            _selectedSummary.value = SelectedSummary(totalPrice, itemCount)
         }
     }
 }

--- a/app/src/main/java/org/techtown/twosomeheart/presentation/mymenu/MyMenuViewModel.kt
+++ b/app/src/main/java/org/techtown/twosomeheart/presentation/mymenu/MyMenuViewModel.kt
@@ -34,6 +34,7 @@ class MyMenuViewModel : ViewModel() {
                         menuPrice = item.price,
                         menuImage = item.imageUrl,
                         menuOption = "${item.temperature}/${item.size}/${item.coffeeBean}/${item.togo}${if(item.personal){"/개인컵"}else{""}}",
+                        id = item.id,
                         isChecked = false // 기본값 설정
                     )
                 }.toPersistentList()
@@ -45,6 +46,43 @@ class MyMenuViewModel : ViewModel() {
                 _state.value = _state.value.copy(
                     uiState = UiState.Failure
                 )
+            }
+        }
+    }
+
+    fun deleteSelectedItems(isAll: Boolean = false) {
+        viewModelScope.launch {
+            val currentState = _state.value
+            if (currentState.uiState is UiState.Success) {
+                val selectedIds = if (isAll) {
+                    currentState.uiState.data.map { it.id } // 전체 삭제 시 모든 ID 가져오기
+                } else {
+                    currentState.uiState.data.filter { it.isChecked }.map { it.id } // 선택된 ID만 가져오기
+                }
+
+                if (selectedIds.isNotEmpty()) {
+                    runCatching {
+                        twosomeService.deleteMyMenu(
+                            favoriteIds = if (!isAll) selectedIds.joinToString(",") else null,
+                            all = isAll
+                        )
+                    }.onSuccess {
+                        // 성공 시 UI 업데이트
+                        val updatedList = if (isAll) {
+                            persistentListOf() // 전체 삭제 시 빈 리스트 반환
+                        } else {
+                            currentState.uiState.data.filter { !it.isChecked }.toPersistentList()
+                        }
+
+                        _state.value = currentState.copy(
+                            uiState = UiState.Success(updatedList)
+                        )
+                    }.onFailure {
+                        _state.value = currentState.copy(
+                            uiState = UiState.Failure
+                        )
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/org/techtown/twosomeheart/presentation/mymenu/model/MyMenuModel.kt
+++ b/app/src/main/java/org/techtown/twosomeheart/presentation/mymenu/model/MyMenuModel.kt
@@ -10,3 +10,8 @@ data class MyMenuModel(
     val isChecked: Boolean,
     val id: Long
 )
+
+data class SelectedSummary(
+    val totalPrice: Int,
+    val itemCount: Int
+)

--- a/app/src/main/java/org/techtown/twosomeheart/presentation/mymenu/model/MyMenuModel.kt
+++ b/app/src/main/java/org/techtown/twosomeheart/presentation/mymenu/model/MyMenuModel.kt
@@ -8,4 +8,5 @@ data class MyMenuModel(
     val menuImage: String,
     val menuOption: String,
     val isChecked: Boolean,
+    val id: Long
 )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,6 +39,7 @@
     <string name="my_menu_item_move_ic">이동 아이콘</string>
     <string name="my_menu_order_message">주문하기</string>
     <string name="my_menu_order_price">주문 금액</string>
+    <string name="my_menu_navigate_text">My 투썸</string>
 
   //menu detail view
     <string name="menu_detail_nutrition_button">제품 영양 정보 버튼</string>
@@ -51,5 +52,4 @@
     <string name="menu_detail_allergy_title_text">알레르기 유발요인</string>
     <string name="menu_detail_order_text">주문하기</string>
     <string name="menu_detail_image">메뉴 상세보기 이미지</string>
-
 </resources>


### PR DESCRIPTION
# PR Convention

## ☕ ISSUE
- closed #42 

## ❗ WORK DESCRIPTION
- 마이투썸 삭제 API 연동을 진행했습니다.

## 📸 SCREENSHOT

<video src="https://github.com/user-attachments/assets/a60ee55d-dd27-4c2a-9f34-fc57a265abc2" width="300"></video>


## 💻 주요 코드

## 📢 TO REVIEWERS
레전드 급하게 해서 해당 이슈에 토탈 개수 및 바텀시트 개수 연동을 동시에 진행했어요ㅠㅠ 
너그러운 이해 부탁드려요 🙏🙏

본가에서 가져온 실기기로 테스트도 해봤어요!! 안드 너무 재밋다아~~

