### PR TITLE
fix/#49: Detail 컴포넌트 패딩 값 변경

### DIFF
--- a/app/src/main/java/org/techtown/twosomeheart/presentation/detail/component/MenuDetailContent.kt
+++ b/app/src/main/java/org/techtown/twosomeheart/presentation/detail/component/MenuDetailContent.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
@@ -24,16 +23,16 @@ fun MenuDetailContent(
     menuName: String,
     menuDescription: String,
     menuPrice: Int,
-    menuCaution : String?,
-    menuAllergy : String?,
+    menuCaution: String?,
+    menuAllergy: String?,
     modifier: Modifier = Modifier
-){
+) {
     val cautionList = menuCaution?.split(",")?.map { it.trim() } ?: emptyList()
     val cautionAndAllergyList = (cautionList + listOfNotNull(menuAllergy)).distinct()
 
     Column(
         modifier = modifier
-            .padding(start = 16.dp)
+            .padding(horizontal = 16.dp)
             .background(White)
     ) {
         MenuStatusChip(isBestMenu = isBestMenu)


### PR DESCRIPTION
# PR Convention

## ☕ ISSUE
- closed #49

## ❗ WORK DESCRIPTION
- 텍스트가 길어졌을때를 고려해 디자인 수정

## 📸 SCREENSHOT
<img src="https://github.com/user-attachments/assets/6725b82f-0a78-4d2c-83fe-752389ed6798" width="300" />

## 📢 TO REVIEWERS
- 탑바 정렬문제는..카테고리나 메뉴 개수가 적어서 생기는 문제라서 패딩값 관련해서만 수정했어용 :)
- 레전드 4줄 PR 발생
